### PR TITLE
Add database support so comments are stored indefinitely 

### DIFF
--- a/portfolio/pom.xml
+++ b/portfolio/pom.xml
@@ -33,6 +33,11 @@
       <artifactId>auto-value</artifactId>
       <version>1.2</version>
     </dependency>
+    <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-api-1.0-sdk</artifactId>
+      <version>1.9.59</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/portfolio/src/main/java/com/google/sps/data/Comment.java
+++ b/portfolio/src/main/java/com/google/sps/data/Comment.java
@@ -19,15 +19,17 @@ import com.google.auto.value.AutoValue;
 /** Class used to create object to store comment data */
 // TODO: Add database id feild for each comment.
 @AutoValue public abstract class Comment {
+  public abstract Long id();
   public abstract String name();
   public abstract String commentText();
+  public abstract Long timeStamp();
 
   /** 
    * Creates comment object
    * @param name Name of author
    * @param commentText Text author wrote
    */
-  public static Comment create(String name, String commentText) {
-    return new AutoValue_Comment(name, commentText);
+  public static Comment create(Long id, String name, String commentText, Long timeStamp) {
+    return new AutoValue_Comment(id, name, commentText, timeStamp);
   }
 }

--- a/portfolio/src/main/java/com/google/sps/data/Comment.java
+++ b/portfolio/src/main/java/com/google/sps/data/Comment.java
@@ -16,7 +16,7 @@ package com.google.sps.data;
 
 import com.google.auto.value.AutoValue;
 
-/** Creates a Comment for each comment written in portfoilio */
+/** Creates a Comment for each comment written in portfolio. */
 @AutoValue 
 public abstract class Comment {
   public abstract Long id();

--- a/portfolio/src/main/java/com/google/sps/data/Comment.java
+++ b/portfolio/src/main/java/com/google/sps/data/Comment.java
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,18 +16,20 @@ package com.google.sps.data;
 
 import com.google.auto.value.AutoValue;
 
-/** Class used to create object to store comment data */
-// TODO: Add database id feild for each comment.
-@AutoValue public abstract class Comment {
+/** Creates a Comment for each comment written in portfoilio */
+@AutoValue 
+public abstract class Comment {
   public abstract Long id();
   public abstract String name();
   public abstract String commentText();
   public abstract Long timeStamp();
 
   /** 
-   * Creates comment object
+   * Creates a Comment.
+   * @param id Id of object stored in database
    * @param name Name of author
    * @param commentText Text author wrote
+   * @param timeStamp Time when author submitted comment
    */
   public static Comment create(Long id, String name, String commentText, Long timeStamp) {
     return new AutoValue_Comment(id, name, commentText, timeStamp);

--- a/portfolio/src/main/java/com/google/sps/data/Comment.java
+++ b/portfolio/src/main/java/com/google/sps/data/Comment.java
@@ -16,7 +16,7 @@ package com.google.sps.data;
 
 import com.google.auto.value.AutoValue;
 
-/** Creates a Comment for each comment written in portfolio. */
+/** Stores data for comments written in portfolio. */
 @AutoValue 
 public abstract class Comment {
   public abstract Long id();

--- a/portfolio/src/main/java/com/google/sps/data/Comment.java
+++ b/portfolio/src/main/java/com/google/sps/data/Comment.java
@@ -19,10 +19,10 @@ import com.google.auto.value.AutoValue;
 /** Stores data for comments written in portfolio. */
 @AutoValue 
 public abstract class Comment {
-  public abstract Long id();
+  public abstract long id();
   public abstract String name();
   public abstract String commentText();
-  public abstract Long timeStamp();
+  public abstract long timeStamp();
 
   /** 
    * Creates a Comment.
@@ -31,7 +31,7 @@ public abstract class Comment {
    * @param commentText Text author wrote
    * @param timeStamp Time when author submitted comment
    */
-  public static Comment create(Long id, String name, String commentText, Long timeStamp) {
+  public static Comment create(long id, String name, String commentText, long timeStamp) {
     return new AutoValue_Comment(id, name, commentText, timeStamp);
   }
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -18,8 +18,17 @@ package com.google.sps.servlets;
 
 import java.util.*; 
 import com.google.gson.Gson;
-import java.io.IOException;
 import com.google.sps.data.Comment;
+
+import com.google.appengine.api.datastore.PreparedQuery;
+import com.google.appengine.api.datastore.Query;
+import com.google.appengine.api.datastore.Query.SortDirection;
+
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+
+import java.io.IOException;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -29,21 +38,21 @@ import javax.servlet.http.HttpServletResponse;
 // TODO: Modify servlet to store values in database.
 @WebServlet("/data")
 public class DataServlet extends HttpServlet {
-  
-  /** Hard coded messages used for tesing JSON */
-  private List<Comment> messages;
-
-  @Override
-  public void init() {
-    messages = new ArrayList<>();
-  }
 
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
     String name = getParameter(request, /* name= */ "name-input", /* defaultValue= */ "");
     String commentText = getParameter(request, /* name= */ "comment-input", /* defaultValue= */ "");
+    long timeStamp = System.currentTimeMillis();
 
-    messages.add(Comment.create(name, commentText));
+    Entity commentEntity = new Entity("Comment");
+    commentEntity.setProperty("name", name);
+    commentEntity.setProperty("commentText", commentText);
+    commentEntity.setProperty("timeStamp", timeStamp);
+
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    datastore.put(commentEntity);
+
     response.sendRedirect("/html/comments.html");
   }
 
@@ -63,10 +72,24 @@ public class DataServlet extends HttpServlet {
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    Gson gson = new Gson();
-    String json = gson.toJson(messages);
+    Query query = new Query("Comment").addSort("timeStamp", SortDirection.DESCENDING);
 
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    PreparedQuery results = datastore.prepare(query);
+
+    List<Comment> comments = new ArrayList<>();
+    for (Entity entity : results.asIterable()) {
+      long id = entity.getKey().getId();
+      String name = (String) entity.getProperty("name");
+      String commentText = (String) entity.getProperty("commentText");
+      long timeStamp = (long) entity.getProperty("timeStamp");
+
+      Comment newComment = Comment.create(id, name, commentText, timeStamp);
+      comments.add(newComment);
+    }
+
+    Gson gson = new Gson();
     response.setContentType("text/html;");
-    response.getWriter().println(json);
+    response.getWriter().println(gson.toJson(comments));
   }
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -45,7 +45,7 @@ public class DataServlet extends HttpServlet {
   private static final String COMMENT_INPUT = "comment-input";
   /** Default value if comment section inputs are empty */
   private static final String DEFAULT_VALUE = "";
-  public static final String REDIRECT_URL = "/html/comments.html";
+  private static final String REDIRECT_URL = "/html/comments.html";
 
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -29,7 +29,7 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-/** Servlet that writes an list of messages as a response. */
+/** Servlet that writes messages as a response. */
 @WebServlet("/data")
 public class DataServlet extends HttpServlet {
   

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -98,7 +98,7 @@ public class DataServlet extends HttpServlet {
     }
 
     Gson gson = new Gson();
-    response.setContentType("text/html;");
+    response.setContentType("text/html");
     response.getWriter().println(gson.toJson(comments));
   }
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -36,9 +36,15 @@ public class DataServlet extends HttpServlet {
   private static final String TIME_STAMP = "timeStamp";
   private static final String NAME = "name";
   private static final String COMMENT_TEXT = "commentText";
+  
+  /** Name of input field used for author name in comments section */
   private static final String NAME_INPUT = "name-input";
+  /** Name of input field used for comment text in comments section */
   private static final String COMMENT_INPUT = "comment-input";
+  /** Default value if comment section inputs are empty */
   private static final String DEFAULT_VALUE = "";
+  public static final String REDIRECT_URL = "/html/comments.html";
+
 
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -72,7 +72,6 @@ public class DataServlet extends HttpServlet {
   /** Queries database for commenting in most recent time stamp order and writes comments as JSON to client */
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
     Query query = new Query("Comment").addSort("timeStamp", SortDirection.ASCENDING);
-
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     PreparedQuery results = datastore.prepare(query);
 
@@ -82,7 +81,8 @@ public class DataServlet extends HttpServlet {
       String name = (String) entity.getProperty("name");
       String commentText = (String) entity.getProperty("commentText");
       long timeStamp = (long) entity.getProperty("timeStamp");
-
+      
+      // Creates new comment object for JSON accessibility
       Comment newComment = Comment.create(id, name, commentText, timeStamp);
       comments.add(newComment);
     }

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -32,16 +32,18 @@ import javax.servlet.http.HttpServletResponse;
 /** Servlet that writes an list of messages as a response. */
 @WebServlet("/data")
 public class DataServlet extends HttpServlet {
-  public static final String COMMENT = "Comment";
-  public static final String TIME_STAMP = "timeStamp";
-  public static final String NAME = "name";
-  public static final String COMMENT_TEXT = "commentText";
+  private static final String COMMENT = "Comment";
+  private static final String TIME_STAMP = "timeStamp";
+  private static final String NAME = "name";
+  private static final String COMMENT_TEXT = "commentText";
+  private static final String NAME_INPUT = "name-input";
+  private static final String COMMENT_INPUT = "comment-input";
+  private static final String DEFAULT_VALUE = "";
 
-  /** Creates a "comment" entity and stores in database */
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    String name = getParameter(request, /* textArea name= */ "name-input", /* defaultValue= */ "");
-    String commentText = getParameter(request, /* textArea name= */ "comment-input", /* defaultValue= */ "");
+    String name = getParameter(request, NAME_INPUT, DEFAULT_VALUE);
+    String commentText = getParameter(request, COMMENT_INPUT, DEFAULT_VALUE);
     long timeStamp = System.currentTimeMillis();
 
     Entity commentEntity = new Entity(COMMENT);
@@ -69,10 +71,6 @@ public class DataServlet extends HttpServlet {
     return value;
   }
 
-  /**
-   * Queries database for comments and writes them to {@code response} as JSON. 
-   * Comments are written in order of most recent time stamp.
-   */
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
     Query query = new Query(COMMENT).addSort(TIME_STAMP, SortDirection.ASCENDING);

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -32,6 +32,7 @@ import javax.servlet.http.HttpServletResponse;
 /** Servlet that writes an list of messages as a response. */
 @WebServlet("/data")
 public class DataServlet extends HttpServlet {
+  /** Used to set Entity and its fields */
   private static final String COMMENT = "Comment";
   private static final String TIME_STAMP = "timeStamp";
   private static final String NAME = "name";
@@ -64,10 +65,10 @@ public class DataServlet extends HttpServlet {
   }
 
   /**
-   * Gets value from form in comments section of portfolio and returns it. If form is empty,
-   * function will return defaultValue passed in.
+   * Returns value with {@code name} from the {@code request} form. 
+   * If the {@code name} cannot be found, return {@code defaultValue}.
    * @param request Form sent by client
-   * @param name textArea to retrive information from
+   * @param name {@code <input>} or {@code <textarea>} to read content of
    */
   private String getParameter(HttpServletRequest request, String name, String defaultValue) {
     String value = request.getParameter(name);
@@ -90,7 +91,7 @@ public class DataServlet extends HttpServlet {
       String commentText = (String) entity.getProperty(COMMENT_TEXT);
       long timeStamp = (long) entity.getProperty(TIME_STAMP);
       
-      // Creates new comment object for JSON accessibility
+      // Creates new Comment for JSON accessibility
       Comment newComment = Comment.create(id, name, commentText, timeStamp);
       comments.add(newComment);
     }

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// TODO: Modify servlet to access multiple messages from servlet.
-
 package com.google.sps.servlets;
 
 import java.util.*; 
@@ -35,11 +33,11 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 /** Servlet that writes an list of messages as a response. */
-// TODO: Modify servlet to store values in database.
 @WebServlet("/data")
 public class DataServlet extends HttpServlet {
 
   @Override
+  /** Creates a "comment" entity and stores in database */
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
     String name = getParameter(request, /* name= */ "name-input", /* defaultValue= */ "");
     String commentText = getParameter(request, /* name= */ "comment-input", /* defaultValue= */ "");
@@ -71,8 +69,9 @@ public class DataServlet extends HttpServlet {
   }
 
   @Override
+  /** Queries database for commenting in most recent time stamp order and writes comments as JSON to client */
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    Query query = new Query("Comment").addSort("timeStamp", SortDirection.DESCENDING);
+    Query query = new Query("Comment").addSort("timeStamp", SortDirection.ASCENDING);
 
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     PreparedQuery results = datastore.prepare(query);

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -32,7 +32,8 @@ import javax.servlet.http.HttpServletResponse;
 /** Servlet that writes an list of messages as a response. */
 @WebServlet("/data")
 public class DataServlet extends HttpServlet {
-  /** Used to set Entity and its fields */
+  
+  /** Used to create Entity and its fields */
   private static final String COMMENT = "Comment";
   private static final String TIME_STAMP = "timeStamp";
   private static final String NAME = "name";
@@ -46,13 +47,13 @@ public class DataServlet extends HttpServlet {
   private static final String DEFAULT_VALUE = "";
   public static final String REDIRECT_URL = "/html/comments.html";
 
-
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
     String name = getParameter(request, NAME_INPUT, DEFAULT_VALUE);
     String commentText = getParameter(request, COMMENT_INPUT, DEFAULT_VALUE);
     long timeStamp = System.currentTimeMillis();
 
+    // Creates Entity and stores in database
     Entity commentEntity = new Entity(COMMENT);
     commentEntity.setProperty(NAME, name);
     commentEntity.setProperty(COMMENT_TEXT, commentText);
@@ -61,7 +62,7 @@ public class DataServlet extends HttpServlet {
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     datastore.put(commentEntity);
 
-    response.sendRedirect("/html/comments.html");
+    response.sendRedirect(REDIRECT_URL);
   }
 
   /**

--- a/portfolio/src/main/webapp/html/comments.html
+++ b/portfolio/src/main/webapp/html/comments.html
@@ -8,7 +8,7 @@
   </head>
   <body onLoad="getData()">
     <div id="content">
-      <h1>POST TEST</h1>
+      <h1>MVP</h1>
       <form action="/data" method="POST">
         <p>Enter your name:</p>
         <textarea name="name-input"></textarea>

--- a/portfolio/src/main/webapp/html/comments.html
+++ b/portfolio/src/main/webapp/html/comments.html
@@ -11,7 +11,7 @@
       <h1>MVP</h1>
       <form action="/data" method="POST">
         <p>Enter your name:</p>
-        <textarea name="name-input"></textarea>
+        <input type="text" name="name-input">
         <br/>
         <br/>
         <p>Enter your comment:</p>

--- a/portfolio/src/main/webapp/script/comment-script.js
+++ b/portfolio/src/main/webapp/script/comment-script.js
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/** Spaces out comment text from author name */
+/** Spaces out comment text from author name. */
 const commentHyphen = " -";
 
 /**
@@ -31,9 +31,7 @@ async function getData() {
 }
 
 /** 
- * Creates an <li> element containing text from comment. 
- * @param {String} text Text to be placed in new element.
- * @return {<li>} liElement Element to be appended in comments section of portfolio.
+ * Creates and returns list element (<li>) containing {@code text} from comment.
  */
 function createListElement(text) {
   const liElement = document.createElement('li');

--- a/portfolio/src/main/webapp/script/comment-script.js
+++ b/portfolio/src/main/webapp/script/comment-script.js
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 /** Spaces out comment text from author name. */
-const commentHyphen = " -";
+const commentHyphen = ' -';
 
 /**
  * Fetches data from servlet and sets it in the comments section of portfolio.

--- a/portfolio/src/main/webapp/script/comment-script.js
+++ b/portfolio/src/main/webapp/script/comment-script.js
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/** @const commentHyphen used to space out comment text from author name */
+/** Spaces out comment text from author name */
 const commentHyphen = " -";
+
 /**
  * Fetches data from servlet and sets it in the comments section of portfolio.
  * Called whenever comments section is loaded.


### PR DESCRIPTION
This pull request adjust comments section such that when a `<form>` is submitted, the `comment` data is stored in a database. This allows for `comment` data to persist outside the life of the server.

Screenshots: https://screenshot.googleplex.com/6rt27rTjhso.png